### PR TITLE
fix build for libcrypto.so.10

### DIFF
--- a/lambda2/build.sh
+++ b/lambda2/build.sh
@@ -5,7 +5,11 @@
 rm layer.zip
 
 docker run --rm -v "$PWD":/tmp/layer lambci/yumda:2 bash -c "
-  yum install -y git-${GIT_VERSION} && \
+  yum install -y git-${GIT_VERSION} openssl-libs openssl-devel && \
   cd /lambda/opt && \
+  # Copy required OpenSSL libraries
+  mkdir -p lib && \
+  cp -a /usr/lib64/libcrypto.so* lib/ && \
+  cp -a /usr/lib64/libssl.so* lib/ && \
   zip -yr /tmp/layer/layer.zip .
 "


### PR DESCRIPTION
On our upgrade to `nodejs22.x` we discovered issues with ssh cloning
it seems that the layer is missing `libcrypto` and `libssl`
rebuild it with the missing dependencies 

qaed it by ssh cloning a repo